### PR TITLE
WHF-51: Add Setting to Choose if Payment Link is Sent on Email

### DIFF
--- a/CRM/Altinvoice/Hook/BuildForm/PreferencesContribute.php
+++ b/CRM/Altinvoice/Hook/BuildForm/PreferencesContribute.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Class CRM_Altinvoice_Hook_BuildForm_PreferencesContribute
+ *
+ * Processes buildForm stage for the Civicontribute preferences form.
+ */
+class CRM_Altinvoice_Hook_BuildForm_PreferencesContribute {
+
+  /**
+   * @var \CRM_Admin_Form_Preferences_Contribute
+   */
+  private $form;
+
+  /**
+   * CRM_Altinvoice_Hook_BuildForm_PreferencesContribute constructor.
+   *
+   * @param \CRM_Admin_Form_Preferences_Contribute $form
+   */
+  public function __construct(CRM_Admin_Form_Preferences_Contribute $form) {
+    $this->form = $form;
+  }
+
+  /**
+   * Further processes buildform stage for the given form.
+   */
+  public function buildForm() {
+    $this->addFields();
+    $this->addTemplates();
+    $this->setDefaults();
+  }
+
+  /**
+   * Adds ne fields to the form.
+   */
+  private function addFields() {
+    $this->form->add('advcheckbox', 'include_link_to_pay', ts('Include Link to Pay Invoice When Emailing Invoices?'));
+  }
+
+  /**
+   * Adds templates to the form to show the new fields.
+   */
+  private function addTemplates() {
+    $templatePath = CRM_Altinvoice_ExtensionUtil::path() . '/templates';
+    CRM_Core_Region::instance('page-body')->add([
+      'template' => "{$templatePath}/CRM/Altinvoice/Form/Settings/IncludeLinkOnEmails.tpl"
+    ]);
+  }
+
+  /**
+   * Sets default values for the new fields on the form.
+   */
+  private function setDefaults() {
+    $isLinkFlagSet = Civi::settings()->get('altinvoice_include_link_to_pay');
+    $defaults = $this->form->_defaultValues;
+    $defaults['include_link_to_pay'] = $isLinkFlagSet ? TRUE : FALSE;
+    $this->form->setDefaults($defaults);
+  }
+
+}

--- a/CRM/Altinvoice/Hook/PostProcess/PreferencesContribute.php
+++ b/CRM/Altinvoice/Hook/PostProcess/PreferencesContribute.php
@@ -1,0 +1,29 @@
+<?php
+
+class CRM_Altinvoice_Hook_PostProcess_PreferencesContribute {
+
+  /**
+   * Form to be post processed.
+   *
+   * @var \CRM_Admin_Form_Preferences_Contribute
+   */
+  private $form;
+
+  public function __construct(CRM_Admin_Form_Preferences_Contribute$form) {
+    $this->form = $form;
+  }
+
+  /**
+   * Post-processes the form.
+   */
+  public function postProcess() {
+    $isIncludePaymentLink = $this->form->getElementValue('include_link_to_pay');
+
+    if ($isIncludePaymentLink) {
+      Civi::settings()->set('altinvoice_include_link_to_pay', TRUE);
+    } else {
+      Civi::settings()->set('altinvoice_include_link_to_pay', FALSE);
+    }
+  }
+
+}

--- a/altinvoice.php
+++ b/altinvoice.php
@@ -55,12 +55,17 @@ function altinvoice_civicrm_alterMailParams(&$params, $context) {
         'id' => $params['contactId'],
         'cs' => $checksum,
       ];
-      $payUrl = CRM_Utils_System::url('civicrm/user', $urlParams, TRUE);
-      $params['text'] .= "\nClick here to pay this invoice: $payUrl";
-      $params['html'] .= "<p>Click here to <a href='$payUrl'>pay this invoice</a>.</p>";
+
+      $isLinkFlagSet = Civi::settings()->get('altinvoice_include_link_to_pay');
+      if ($isLinkFlagSet) {
+        $payUrl = CRM_Utils_System::url('civicrm/user', $urlParams, TRUE);
+        $params['text'] .= "\nClick here to pay this invoice: $payUrl";
+        $params['html'] .= "<p>Click here to <a href='$payUrl'>pay this invoice</a>.</p>";
+      }
     }
   }
 }
+
 /**
  * Implements hook_civicrm_config().
  *
@@ -190,6 +195,26 @@ function altinvoice_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  */
 function altinvoice_civicrm_entityTypes(&$entityTypes) {
   _altinvoice_civix_civicrm_entityTypes($entityTypes);
+}
+
+/**
+ * Implements hook_civicrm_buildForm()
+ */
+function altinvoice_civicrm_buildForm($formName, &$form) {
+  if ($formName === 'CRM_Admin_Form_Preferences_Contribute') {
+    $formBuilder = new CRM_Altinvoice_Hook_BuildForm_PreferencesContribute($form);
+    $formBuilder->buildForm();
+  }
+}
+
+/**
+ * Implements hook_civicrm_postProcess()
+ */
+function altinvoice_civicrm_postProcess($formName, &$form) {
+  if ($formName === 'CRM_Admin_Form_Preferences_Contribute') {
+    $formPostProcessor = new CRM_Altinvoice_Hook_PostProcess_PreferencesContribute($form);
+    $formPostProcessor->postProcess();
+  }
 }
 
 // --- Functions below this ship commented out. Uncomment as required. ---

--- a/settings/Altinvoice.setting.php
+++ b/settings/Altinvoice.setting.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+  'altinvoice_include_link_to_pay' => [
+    'group_name' => 'Altinvoice: Settings',
+    'group' => 'altinvoice_settings',
+    'name' => 'altinvoice_include_link_to_pay',
+    'title' => 'Include Link to Pay Invoice When Emailing Invoices?',
+    'type' => 'Integer',
+    'html_type' => 'checkbox',
+    'quick_form_type' => 'Element',
+    'default' => TRUE,
+    'is_required' => FALSE,
+  ],
+];

--- a/templates/CRM/Altinvoice/Form/Settings/IncludeLinkOnEmails.tpl
+++ b/templates/CRM/Altinvoice/Form/Settings/IncludeLinkOnEmails.tpl
@@ -1,0 +1,17 @@
+<table>
+  <tr id="include_link_to_pay">
+    <td class="label">&nbsp;</td>
+    <td>
+        {$form.include_link_to_pay.html}
+        {$form.include_link_to_pay.label}
+    </td>
+  </tr>
+</table>
+<script type="text/javascript">
+  {literal}
+	CRM.$(function($) {
+		targetElement = $('.crm-preferences-form-block-is_email_pdf');
+		$('#include_link_to_pay').insertAfter(targetElement);
+	});
+	{/literal}
+</script>


### PR DESCRIPTION
## Overview
Some clients have asked us that they would not like to send the email for the invoice with the link to pay for it, as they do not have any payment methods set-up.

## Before
E-mail with the invoice is always sent with a link to pay for it.

## After
Added a setting to Civicontribute settings form to choose if we want to send the payment link on the email or not.

Ref: https://github.com/MegaphoneJon/com.megaphonetech.altinvoice/issues/2